### PR TITLE
Integrate loan simulator with Marlene agent

### DIFF
--- a/src/app/agentConfigs/utils.ts
+++ b/src/app/agentConfigs/utils.ts
@@ -828,6 +828,30 @@ export const includeCompanionTool: Tool = {
 };
 
 /**
+ * Ferramenta para consulta de benefício e limites disponíveis
+ */
+export const consultBenefitTool: Tool = {
+  type: "function",
+  name: "consult_benefit",
+  description:
+    "Consulta informações do benefício do cliente para calcular margem e limite",
+  parameters: {
+    type: "object",
+    properties: {
+      benefitNumber: {
+        type: "string",
+        description: "Número do benefício do INSS",
+      },
+      customerName: {
+        type: "string",
+        description: "Nome do cliente",
+      },
+    },
+    required: ["benefitNumber"],
+  },
+};
+
+/**
  * Ferramenta para criação de documentação acessível
  */
 export const createAccessibleDocumentationTool: Tool = {

--- a/src/app/loanSimulator.ts
+++ b/src/app/loanSimulator.ts
@@ -1,0 +1,70 @@
+export interface BeneficioInfo {
+  benefitNumber: string;
+  fullName: string;
+  benefitType: string;
+  benefitValue: number;
+  marginPercent: number;
+  marginValue: number;
+  availableLimit: number;
+}
+
+export interface EmprestimoResultado {
+  parcela: number;
+  total: number;
+  term: number;
+  impactoPercentual: number;
+}
+
+/**
+ * Consulta informações do benefício de forma simulada
+ */
+export function consultarBeneficio(benefitNumber: string): BeneficioInfo {
+  const benefitValue = 1800;
+  const marginPercent = 30;
+  const marginValue = (benefitValue * marginPercent) / 100;
+  const availableLimit = 15000;
+
+  return {
+    benefitNumber,
+    fullName: "Cliente",
+    benefitType: "Aposentadoria por Tempo de Contribuição",
+    benefitValue,
+    marginPercent,
+    marginValue,
+    availableLimit,
+  };
+}
+
+/**
+ * Simula um empréstimo consignado
+ */
+export function simularEmprestimo(
+  amount: number,
+  benefitValue: number,
+  term = 60,
+  rate = 0.018
+): EmprestimoResultado {
+  const parcela = Math.round(
+    (amount * (rate * Math.pow(1 + rate, term))) /
+      (Math.pow(1 + rate, term) - 1)
+  );
+
+  return {
+    parcela,
+    total: parcela * term,
+    term,
+    impactoPercentual: Math.round((parcela / benefitValue) * 100),
+  };
+}
+
+/**
+ * Texto simplificado para Marlene apresentar a simulação
+ */
+export function calcularApresentacaoMarlene(
+  simulacao: EmprestimoResultado,
+  _beneficio: BeneficioInfo
+): string {
+  return `Com base no benefício, a parcela seria de R$ ${simulacao.parcela.toLocaleString(
+    'pt-BR'
+  )}, durante ${simulacao.term} meses, comprometendo cerca de ${simulacao.impactoPercentual}% do benefício.`;
+}


### PR DESCRIPTION
## Summary
- wire new `loanSimulator` module into Marlene agent
- add `consult_benefit` tool
- update tool logic to use benefit consultation and loan simulation
- tweak dialogue instructions to use placeholders

## Testing
- `npm run lint` *(fails: no-unused-vars, parsing error)*