### PR TITLE
Fix contexts for client and add encoding dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.3",
-    "uuid": "^11.0.4"
+    "uuid": "^11.0.4",
+    "encoding": "^0.1.13"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/simple/contexts/CameraContext.tsx
+++ b/src/app/simple/contexts/CameraContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useReducer, useRef, useEffect } from 'react';
 import { CameraState } from '../types';
 import * as faceapi from 'face-api.js';

--- a/src/app/simple/contexts/ConnectionContext.tsx
+++ b/src/app/simple/contexts/ConnectionContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useEffect } from 'react';
 import { useWebRTCConnection } from '../hooks/useWebRTCConnection';
 import { ConnectionState } from '../types';

--- a/src/app/simple/contexts/SimulationContext.tsx
+++ b/src/app/simple/contexts/SimulationContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/SimulationContext.tsx
 import React, { createContext, useContext, useState, useEffect } from 'react';
 

--- a/src/app/simple/contexts/UIContext.tsx
+++ b/src/app/simple/contexts/UIContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/UIContext.tsx
 import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { UIEvent, CameraRequest, LoanState } from '../types';

--- a/src/app/simple/contexts/VerificationContext.tsx
+++ b/src/app/simple/contexts/VerificationContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/VerificationContext.tsx
 import React, { createContext, useContext, useReducer, useRef, useEffect } from 'react';
 import { VerificationState } from '../types';


### PR DESCRIPTION
## Summary
- mark React context modules as client components
- add missing `encoding` dependency in `package.json`

## Testing
- `npm run lint`
