### PR TITLE
Fix missing API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ You should be able to use this repo to prototype your own multi-agent realtime v
 
 - This is a Next.js typescript app
 - Install dependencies with `npm i`
-- Add your `OPENAI_API_KEY` to your env
+- Create an `.env` file and add your OpenAI keys:
+  ```
+  OPENAI_API_KEY=<your-server-key>
+  NEXT_PUBLIC_OPENAI_API_KEY=<your-client-key>
+  ```
+- After editing `package.json` run `npm install` again so new dependencies like `encoding` are installed.
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000) to see the app. It should automatically connect to the `simpleExample` Agent Set.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.3",
-    "uuid": "^11.0.4"
+    "uuid": "^11.0.4",
+    "encoding": "^0.1.13"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/simple/contexts/CameraContext.tsx
+++ b/src/app/simple/contexts/CameraContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useReducer, useRef, useEffect } from 'react';
 import { CameraState } from '../types';
 import * as faceapi from 'face-api.js';

--- a/src/app/simple/contexts/ConnectionContext.tsx
+++ b/src/app/simple/contexts/ConnectionContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useEffect } from 'react';
 import { useWebRTCConnection } from '../hooks/useWebRTCConnection';
 import { ConnectionState } from '../types';

--- a/src/app/simple/contexts/SimulationContext.tsx
+++ b/src/app/simple/contexts/SimulationContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/SimulationContext.tsx
 import React, { createContext, useContext, useState, useEffect } from 'react';
 

--- a/src/app/simple/contexts/UIContext.tsx
+++ b/src/app/simple/contexts/UIContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/UIContext.tsx
 import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { UIEvent, CameraRequest, LoanState } from '../types';

--- a/src/app/simple/contexts/VerificationContext.tsx
+++ b/src/app/simple/contexts/VerificationContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // src/app/simple/contexts/VerificationContext.tsx
 import React, { createContext, useContext, useReducer, useRef, useEffect } from 'react';
 import { VerificationState } from '../types';

--- a/src/app/simple/hooks/useWebRTCConnection.ts
+++ b/src/app/simple/hooks/useWebRTCConnection.ts
@@ -32,7 +32,18 @@ export const useWebRTCConnection = (): UseWebRTCConnectionResult => {
   // Função para conectar
   const connect = useCallback(async () => {
     if (state.status !== 'disconnected') return;
-    
+
+    const apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
+    if (!apiKey) {
+      console.error('NEXT_PUBLIC_OPENAI_API_KEY is not configured');
+      setState(prev => ({
+        ...prev,
+        status: 'disconnected',
+        error: new Error('API key missing')
+      }));
+      return;
+    }
+
     setState(prev => ({ ...prev, status: 'connecting', error: null }));
     
     try {
@@ -44,7 +55,7 @@ export const useWebRTCConnection = (): UseWebRTCConnectionResult => {
       
       // Criar conexão WebRTC
       const { pc, dc } = await createRealtimeConnection(
-        process.env.NEXT_PUBLIC_OPENAI_API_KEY!,
+        apiKey,
         audioRef
       );
       


### PR DESCRIPTION
## Summary
- document both required environment variables
- remind users to re-run npm install after editing `package.json`
- guard WebRTC connection when `NEXT_PUBLIC_OPENAI_API_KEY` is missing

## Testing
- `npm run lint`
