### PR TITLE
Add client directive to hooks

### DIFF
--- a/src/app/simple/hooks/useAudioAnalysis.ts
+++ b/src/app/simple/hooks/useAudioAnalysis.ts
@@ -1,3 +1,4 @@
+"use client";
 // src/app/simple/hooks/useAudioAnalysis.ts
 import { useEffect, useRef } from 'react';
 import { useUI } from '../contexts/UIContext';

--- a/src/app/simple/hooks/useCamera.ts
+++ b/src/app/simple/hooks/useCamera.ts
@@ -1,3 +1,4 @@
+"use client";
 // src/app/simple/hooks/useCamera.ts
 import { useState, useCallback } from 'react';
 import { handleError } from '../utils/errorHandling';

--- a/src/app/simple/hooks/useVerificationProcess.ts
+++ b/src/app/simple/hooks/useVerificationProcess.ts
@@ -1,3 +1,4 @@
+"use client";
 // src/app/simple/hooks/useVerificationProcess.ts
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useCamera } from './useCamera';

--- a/src/app/simple/hooks/useWebRTCConnection.ts
+++ b/src/app/simple/hooks/useWebRTCConnection.ts
@@ -1,3 +1,4 @@
+"use client";
 // src/app/simple/hooks/useWebRTCConnection.ts
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { createRealtimeConnection } from '@/app/lib/realtimeConnection';


### PR DESCRIPTION
## Summary
- ensure Next treats hooks as client components by adding `"use client"` at the top of each file in `src/app/simple/hooks`

## Testing
- `npm run lint`