### PR TITLE
Add LLM loan backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=your-server-key
 NEXT_PUBLIC_OPENAI_API_KEY=your-client-key
+
+NEXT_PUBLIC_USE_LLM_BACKEND=false

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You should be able to use this repo to prototype your own multi-agent realtime v
 
 ### Loan simulator backend
 Marlene consumes the fake backend under `src/app/loanSimulator`. Running `npm run dev` with the default agent set (`marlene`) uses these functions for loan simulations and Itaú offers.
+If `NEXT_PUBLIC_USE_LLM_BACKEND` is set to `true`, the simulator calls `/api/loan/consult`,
+which generates consistent data via an OpenAI model and stores it in `data/llm-benefit-cache.json`.
 
 ## Configuring Agents
 Configuration in `src/app/agentConfigs/simpleExample.ts`

--- a/src/app/agentConfigs/marlene.ts
+++ b/src/app/agentConfigs/marlene.ts
@@ -17,7 +17,7 @@ import {
   consultBenefitTool
 } from "./utils";
 import {
-  consultarBeneficio,
+  consultarBeneficioAsync,
   simularEmprestimo,
   calcularApresentacaoMarlene,
 } from "../loanSimulator/index";
@@ -653,12 +653,12 @@ Apenas use a ferramenta e continue a conversa normalmente.
     },
     
     // Funções existentes de Marlene
-    verifyCustomerInfo: ({ customerName, benefitNumber }) => {
+    verifyCustomerInfo: async ({ customerName, benefitNumber }) => {
       console.log(
         `[toolLogic] Consultando benefício: ${benefitNumber || "não fornecido"}`
       );
 
-      const info = consultarBeneficio(
+      const info = await consultarBeneficioAsync(
         benefitNumber,
         customerName || "Cliente"
       );
@@ -676,8 +676,8 @@ Apenas use a ferramenta e continue a conversa normalmente.
       };
     },
 
-    consult_benefit: ({ benefitNumber, customerName }) => {
-      const info = consultarBeneficio(
+    consult_benefit: async ({ benefitNumber, customerName }) => {
+      const info = await consultarBeneficioAsync(
         benefitNumber,
         customerName || "Cliente"
       );

--- a/src/app/api/loan/consult/route.ts
+++ b/src/app/api/loan/consult/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+import { promises as fs } from "fs";
+import path from "path";
+
+import { ConsultaBeneficio } from "@/app/loanSimulator";
+
+const openai = new OpenAI();
+const cacheFile = path.join(process.cwd(), "data", "llm-benefit-cache.json");
+let cache: Record<string, ConsultaBeneficio> | null = null;
+
+async function loadCache() {
+  if (cache) return;
+  try {
+    const data = await fs.readFile(cacheFile, "utf8");
+    cache = JSON.parse(data);
+  } catch {
+    cache = {};
+  }
+}
+
+async function saveCache() {
+  if (!cache) return;
+  await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+  await fs.writeFile(cacheFile, JSON.stringify(cache, null, 2));
+}
+
+export async function POST(req: Request) {
+  try {
+    const { numeroBeneficio, nomeCliente } = await req.json();
+    await loadCache();
+    if (cache && cache[numeroBeneficio]) {
+      return NextResponse.json(cache[numeroBeneficio]);
+    }
+
+    const system = {
+      role: "system",
+      content:
+        "Você gera dados fictícios de crédito consignado em formato JSON. Responda APENAS com JSON compatível com a interface ConsultaBeneficio.",
+    };
+    const user = {
+      role: "user",
+      content: `Cliente: ${nomeCliente}. Benefício: ${numeroBeneficio}.`,
+    };
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-3.5-turbo",
+      messages: [system, user],
+      temperature: 0.7,
+    });
+
+    const text = completion.choices?.[0]?.message?.content?.trim() || "{}";
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    const jsonText = text.slice(start, end + 1);
+    const result = JSON.parse(jsonText) as ConsultaBeneficio;
+
+    if (cache) {
+      cache[numeroBeneficio] = result;
+      await saveCache();
+    }
+
+    return NextResponse.json(result);
+  } catch (error: any) {
+    console.error("Error in /loan/consult:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/loanSimulator/index.ts
+++ b/src/app/loanSimulator/index.ts
@@ -226,6 +226,34 @@ export function consultarBeneficio(
   return result;
 }
 
+/**
+ * Versão assíncrona que consulta a rota /api/loan/consult para obter dados
+ * gerados por LLM. Quando a variável NEXT_PUBLIC_USE_LLM_BACKEND estiver
+ * habilitada no ambiente, utiliza essa rota. Caso contrário, recai no
+ * gerador aleatório acima.
+ */
+export async function consultarBeneficioAsync(
+  numeroBeneficio: string,
+  nomeCliente: string
+): Promise<ConsultaBeneficio> {
+  if (process.env.NEXT_PUBLIC_USE_LLM_BACKEND === "true") {
+    try {
+      const resp = await fetch("/api/loan/consult", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ numeroBeneficio, nomeCliente }),
+      });
+      if (resp.ok) {
+        return (await resp.json()) as ConsultaBeneficio;
+      }
+      console.error("LLM backend error", await resp.text());
+    } catch (err) {
+      console.error("Failed to fetch LLM backend", err);
+    }
+  }
+  return consultarBeneficio(numeroBeneficio, nomeCliente);
+}
+
 export function obterOfertasItau({
   banco,
   contratacoes,


### PR DESCRIPTION
## Summary
- add config var `NEXT_PUBLIC_USE_LLM_BACKEND`
- implement `/api/loan/consult` route that generates loan data using OpenAI and caches it
- expose `consultarBeneficioAsync` to call the new API when enabled
- use async benefit lookup in Marlene agent
- document the new flow in README

## Testing
- `npm run lint`