### PR TITLE
Add Jest tests for loan consult route

### DIFF
--- a/__tests__/loanConsult.test.ts
+++ b/__tests__/loanConsult.test.ts
@@ -1,0 +1,77 @@
+import { POST } from '@/app/api/loan/consult/route';
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// mock OpenAI module
+let createMock: jest.Mock;
+jest.mock('openai', () => {
+  createMock = jest.fn();
+  return {
+    default: jest.fn().mockImplementation(() => ({
+      chat: { completions: { create: createMock } },
+    })),
+  };
+});
+
+function makeRequest(body: any) {
+  return new Request('http://localhost/api/loan/consult', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('loan consult route', () => {
+  let cwdSpy: jest.SpyInstance;
+  let tmpDir: string;
+  beforeEach(() => {
+    jest.resetModules();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-test-'));
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    createMock.mockReset();
+  });
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns valid JSON when LLM responds', async () => {
+    createMock.mockResolvedValueOnce({
+      choices: [
+        { message: { content: '{"beneficiario": {"nome": "Jo"}}' } },
+      ],
+    });
+    const req = makeRequest({ numeroBeneficio: '1', nomeCliente: 'Jo' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty('beneficiario');
+  });
+
+  test('uses cache on subsequent call', async () => {
+    createMock.mockResolvedValueOnce({
+      choices: [
+        { message: { content: '{"beneficiario": {"nome": "Ana"}}' } },
+      ],
+    });
+    const body = { numeroBeneficio: '2', nomeCliente: 'Ana' };
+    const res1 = await POST(makeRequest(body));
+    expect(res1.status).toBe(200);
+    await res1.json();
+    const res2 = await POST(makeRequest(body));
+    expect(res2.status).toBe(200);
+    await res2.json();
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 500 on OpenAI failure', async () => {
+    createMock.mockRejectedValueOnce(new Error('boom'));
+    const req = makeRequest({ numeroBeneficio: '3', nomeCliente: 'Eli' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data).toHaveProperty('error');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "face-api.js": "^0.20.0",
@@ -28,7 +29,10 @@
     "eslint-config-next": "15.1.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   },
 "browserlistrc": {
   "production": [


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest
- add test script to `package.json`
- write unit tests for `/api/loan/consult` validating JSON response, cache use, and error handling

## Testing
- `npm test` *(fails: jest not found)*