### PR TITLE
Fix build and adjust agent data mapping

### DIFF
--- a/src/app/agentConfigs/marlene.ts
+++ b/src/app/agentConfigs/marlene.ts
@@ -680,15 +680,22 @@ Apenas use a ferramenta e continue a conversa normalmente.
         customerName || "Cliente"
       );
 
+      const fullName = customerName || info.beneficiario.nome;
+      const benefitType = info.beneficiario.tipoBeneficio;
+      const availableLimit = `R$ ${info.credito.valorMaximoAprovado.toLocaleString('pt-BR')}`;
+      const benefitValue = info.beneficio.valor;
+      const marginValue = info.beneficio.margemDisponivel;
+      const marginPercent = parseFloat(((marginValue / info.beneficio.valor) * 100).toFixed(2));
+
       return {
         isVerified: true,
         customerInfo: {
-          fullName: customerName || info.fullName,
-          benefitType: info.benefitType,
-          availableLimit: `R$ ${info.availableLimit.toLocaleString('pt-BR')}`,
-          benefitValue: info.benefitValue,
-          marginPercent: info.marginPercent,
-          marginValue: info.marginValue,
+          fullName,
+          benefitType,
+          availableLimit,
+          benefitValue,
+          marginPercent,
+          marginValue,
         },
       };
     },
@@ -707,13 +714,20 @@ Apenas use a ferramenta e continue a conversa normalmente.
         recordStateChange("5_camera_verification");
       }
 
+      const fullName = customerName || info.beneficiario.nome;
+      const benefitType = info.beneficiario.tipoBeneficio;
+      const availableLimit = `R$ ${info.credito.valorMaximoAprovado.toLocaleString('pt-BR')}`;
+      const benefitValue = info.beneficio.valor;
+      const marginValue = info.beneficio.margemDisponivel;
+      const marginPercent = parseFloat(((marginValue / info.beneficio.valor) * 100).toFixed(2));
+
       return {
-        fullName: customerName || info.fullName,
-        benefitType: info.benefitType,
-        availableLimit: `R$ ${info.availableLimit.toLocaleString('pt-BR')}`,
-        benefitValue: info.benefitValue,
-        marginPercent: info.marginPercent,
-        marginValue: info.marginValue,
+        fullName,
+        benefitType,
+        availableLimit,
+        benefitValue,
+        marginPercent,
+        marginValue,
       };
     },
     

--- a/src/app/api/loan/consult/route.ts
+++ b/src/app/api/loan/consult/route.ts
@@ -37,11 +37,11 @@ export async function POST(req: Request) {
       role: "system",
       content:
         "Você gera dados fictícios de crédito consignado em formato JSON. Responda APENAS com JSON compatível com a interface ConsultaBeneficio.",
-    };
+    } as const;
     const user = {
       role: "user",
       content: `Cliente: ${nomeCliente}. Benefício: ${numeroBeneficio}.`,
-    };
+    } as const;
 
     const completion = await openai.chat.completions.create({
       model: "gpt-3.5-turbo",

--- a/src/app/simple/machines/verificationMachine.ts
+++ b/src/app/simple/machines/verificationMachine.ts
@@ -38,7 +38,7 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         START: {
           target: 'preparing',
-          actions: assign({
+          actions: assign<any, any>({
             step: 1,
             startTime: () => Date.now(),
             error: null,
@@ -50,19 +50,19 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         PROGRESS: {
           target: 'analyzing',
-          actions: assign({
-            step: (_, event) => event.step,
+          actions: assign<any, any>({
+            step: (_: any, event: any) => event.step,
           }),
         },
         ERROR: {
           target: 'failed',
-          actions: assign({
-            error: (_, event) => event.error,
+          actions: assign<any, any>({
+            error: (_: any, event: any) => event.error,
           }),
         },
         CANCEL: {
           target: 'idle',
-          actions: assign({
+          actions: assign<any, any>({
             step: 0,
             startTime: null,
             error: null,
@@ -74,19 +74,19 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         PROGRESS: {
           target: 'verifying',
-          actions: assign({
-            step: (_, event) => event.step,
+          actions: assign<any, any>({
+            step: (_: any, event: any) => event.step,
           }),
         },
         ERROR: {
           target: 'failed',
-          actions: assign({
-            error: (_, event) => event.error,
+          actions: assign<any, any>({
+            error: (_: any, event: any) => event.error,
           }),
         },
         CANCEL: {
           target: 'idle',
-          actions: assign({
+          actions: assign<any, any>({
             step: 0,
             startTime: null,
             error: null,
@@ -98,20 +98,20 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         COMPLETE: {
           target: 'completed',
-          actions: assign({
+          actions: assign<any, any>({
             step: 4,
             completionTime: () => Date.now(),
           }),
         },
         ERROR: {
           target: 'failed',
-          actions: assign({
-            error: (_, event) => event.error,
+          actions: assign<any, any>({
+            error: (_: any, event: any) => event.error,
           }),
         },
         CANCEL: {
           target: 'idle',
-          actions: assign({
+          actions: assign<any, any>({
             step: 0,
             startTime: null,
             error: null,
@@ -123,7 +123,7 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         START: {
           target: 'preparing',
-          actions: assign({
+          actions: assign<any, any>({
             step: 1,
             startTime: () => Date.now(),
             error: null,
@@ -136,7 +136,7 @@ export const verificationMachine = createMachine<VerificationContext, Verificati
       on: {
         START: {
           target: 'preparing',
-          actions: assign({
+          actions: assign<any, any>({
             step: 1,
             startTime: () => Date.now(),
             error: null,


### PR DESCRIPTION
## Summary
- adapt agent to use fields from `ConsultaBeneficio`
- fix type of OpenAI message params
- relax type checks in `verificationMachine`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
