### PR TITLE
Add verification machine tests

### DIFF
--- a/__tests__/loanConsult.test.ts
+++ b/__tests__/loanConsult.test.ts
@@ -31,6 +31,8 @@ describe('loan consult route', () => {
   let tmpDir: string;
   beforeEach(() => {
     jest.resetModules();
+    const realCwd = process.cwd();
+    fs.rmSync(path.join(realCwd, 'data'), { recursive: true, force: true });
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-test-'));
     cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
     createMock.mockReset();

--- a/__tests__/verificationMachine.test.ts
+++ b/__tests__/verificationMachine.test.ts
@@ -1,0 +1,52 @@
+import { verificationMachine } from '@/app/simple/machines/verificationMachine';
+
+describe('verificationMachine', () => {
+  test('progresses through successful flow', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    let state = verificationMachine.initialState;
+
+    state = verificationMachine.transition(state, { type: 'START' });
+    expect(state.value).toBe('preparing');
+    expect(state.context.step).toBe(1);
+    expect(state.context.startTime).toBe(Date.now());
+
+    state = verificationMachine.transition(state, { type: 'PROGRESS', step: 2 });
+    expect(state.value).toBe('analyzing');
+    expect(state.context.step).toBe(2);
+
+    state = verificationMachine.transition(state, { type: 'PROGRESS', step: 3 });
+    expect(state.value).toBe('verifying');
+    expect(state.context.step).toBe(3);
+
+    jest.setSystemTime(new Date('2024-01-01T01:00:00Z'));
+    state = verificationMachine.transition(state, { type: 'COMPLETE' });
+    expect(state.value).toBe('completed');
+    expect(state.context.step).toBe(4);
+    expect(state.context.completionTime).toBe(Date.now());
+
+    jest.useRealTimers();
+  });
+
+  test('handles cancellation from preparing', () => {
+    let state = verificationMachine.initialState;
+    state = verificationMachine.transition(state, { type: 'START' });
+    state = verificationMachine.transition(state, { type: 'CANCEL' });
+    expect(state.value).toBe('idle');
+    expect(state.context.step).toBe(0);
+    expect(state.context.startTime).toBeNull();
+  });
+
+  test('handles error and restart', () => {
+    let state = verificationMachine.initialState;
+    state = verificationMachine.transition(state, { type: 'START' });
+    const err = new Error('boom');
+    state = verificationMachine.transition(state, { type: 'ERROR', error: err });
+    expect(state.value).toBe('failed');
+    expect(state.context.error).toBe(err);
+
+    state = verificationMachine.transition(state, { type: 'START' });
+    expect(state.value).toBe('preparing');
+    expect(state.context.step).toBe(1);
+    expect(state.context.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test suite for `verificationMachine`
- clean loan consult cache before each test so prior runs don't affect mocks

## Testing
- `npm test`