### PR TITLE
Add conversation utils tests

### DIFF
--- a/__tests__/conversationUtils.test.ts
+++ b/__tests__/conversationUtils.test.ts
@@ -1,0 +1,50 @@
+import { processUserInput, exportContext, resetConversationContext, setCameraVerified } from '@/app/agentConfigs/utils';
+
+beforeEach(() => {
+  resetConversationContext();
+});
+
+describe('processUserInput', () => {
+  test('extracts entities and updates context', () => {
+    const phrase = 'Meu nome é Joao. Meu benefício é 123456. Quero um empréstimo de R$ 50.000 para reforma. Estou com meu filho.';
+    const result = processUserInput(phrase);
+
+    expect(result.entities).toEqual(expect.objectContaining({
+      name: 'Joao',
+      benefitNumber: '123456',
+      requestedAmount: 'R$ 50.000',
+      purpose: 'reforma',
+      hasCompanion: true,
+      companionType: 'filho(a)'
+    }));
+    expect(result.recommendedState).toBe('5_camera_verification');
+
+    const context = exportContext();
+    expect(context.name).toBe('Joao');
+    expect(context.benefitNumber).toBe('123456');
+    expect(context.requestedAmount).toBe('R$ 50.000');
+    expect(context.purpose).toBe('reforma');
+    expect(context.hasCompanion).toBe(true);
+    expect(context.companionType).toBe('filho(a)');
+    expect(context.confirmedEntities.has('benefitNumber')).toBe(true);
+  });
+
+  test('recommends loan simulation when camera is verified', () => {
+    setCameraVerified(true);
+    const phrase = 'Meu benefício é 654321 e quero um empréstimo de R$ 10.000';
+    const result = processUserInput(phrase);
+    expect(result.recommendedState).toBe('6_loan_simulation');
+  });
+
+  test('context persists across multiple inputs', () => {
+    processUserInput('Meu nome é Maria');
+    let context = exportContext();
+    expect(context.name).toBe('Maria');
+    expect(context.benefitNumber).toBeUndefined();
+
+    processUserInput('Número do benefício 111222');
+    context = exportContext();
+    expect(context.name).toBe('Maria');
+    expect(context.benefitNumber).toBe('111222');
+  });
+});

--- a/__tests__/loanConsult.test.ts
+++ b/__tests__/loanConsult.test.ts
@@ -1,4 +1,4 @@
-import { POST } from '@/app/api/loan/consult/route';
+let POST: typeof import('@/app/api/loan/consult/route').POST;
 import { NextResponse } from 'next/server';
 import { consultarBeneficio } from '@/app/loanSimulator';
 import fs from 'fs';
@@ -8,15 +8,6 @@ import os from 'os';
 // mock OpenAI module
 // use `var` so the variable is hoisted and available inside the factory
 var createMock: jest.Mock;
-jest.mock('openai', () => {
-  createMock = jest.fn();
-  return {
-    __esModule: true,
-    default: jest.fn().mockImplementation(() => ({
-      chat: { completions: { create: createMock } },
-    })),
-  };
-});
 
 function makeRequest(body: any) {
   return new Request('http://localhost/api/loan/consult', {
@@ -33,7 +24,14 @@ describe('loan consult route', () => {
     jest.resetModules();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-test-'));
     cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
-    createMock.mockReset();
+    createMock = jest.fn();
+    jest.doMock('openai', () => ({
+      __esModule: true,
+      default: jest.fn().mockImplementation(() => ({
+        chat: { completions: { create: createMock } },
+      })),
+    }));
+    POST = require('@/app/api/loan/consult/route').POST;
   });
   afterEach(() => {
     cwdSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add unit tests for conversation utils
- fix loanConsult route test to reload module per test and mock OpenAI correctly

## Testing
- `npm test`