### PR TITLE
Integrate identity verification flow

### DIFF
--- a/src/app/agentConfigs/marlene.ts
+++ b/src/app/agentConfigs/marlene.ts
@@ -212,6 +212,7 @@ IMPORTANTE: SEMPRE que o usuário mencionar um valor de empréstimo desejado, us
       "Quando receber [ROSTO CENTRALIZADO], diga: 'Muito bem! Seu rosto está na posição perfeita. Agora vou fazer a verificação.'",
       "Quando receber [VERIFICANDO IDENTIDADE], diga: 'Só um momento enquanto eu verifico sua identidade... fique parado, por gentileza.'",
       "Quando receber [VERIFICAÇÃO CONCLUÍDA], diga: 'Perfeito! Consegui verificar sua identidade. Podemos continuar com o empréstimo agora.'",
+      "Quando receber [FECHANDO CÂMERA], diga: 'Vou fechar a câmera para continuarmos.'",
       "Quando receber [AVANÇAR PARA SIMULAÇÃO DE EMPRÉSTIMO], avance para o estado 6_loan_simulation",
       "Varie as formas de tratamento durante este processo para soar natural"
     ],
@@ -225,6 +226,10 @@ IMPORTANTE: SEMPRE que o usuário mencionar um valor de empréstimo desejado, us
       {
         "next_step": "6_loan_simulation",
         "condition": "Após a verificação por câmera ser concluída."
+      },
+      {
+        "next_step": "10_early_exit",
+        "condition": "Se o cliente desistir durante a verificação."
       }
     ]
   },
@@ -778,17 +783,32 @@ Apenas use a ferramenta e continue a conversa normalmente.
     // Função para processar eventos de câmera
     processCameraEvent: (args) => {
       console.log(`[toolLogic] Processando evento de câmera: ${args.eventType}`);
-      
-      if (args.eventType === "VERIFICATION_COMPLETED") {
-        // Marca a verificação como concluída no contexto persistente
+
+      if (args.eventType === "VERIFICATION_CONFIRMED") {
         setCameraVerified(true);
         return {
           success: true,
-          message: "Verificação concluída com sucesso",
+          message: "Verificação confirmada",
           nextStep: "loan_simulation"
         };
       }
-      
+
+      if (args.eventType === "VERIFICATION_FAILED") {
+        return {
+          success: false,
+          message: "Verificação falhou",
+          nextStep: "retry"
+        };
+      }
+
+      if (args.eventType === "VERIFICATION_CANCELLED") {
+        return {
+          success: false,
+          message: "Verificação cancelada",
+          nextStep: "early_exit"
+        };
+      }
+
       return {
         success: true,
         message: `Evento de câmera ${args.eventType} processado`

--- a/src/app/api/verification/route.ts
+++ b/src/app/api/verification/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+
+export async function POST(req: Request) {
+  try {
+    const contentType = req.headers.get("content-type") || "";
+    let imageData: string | null = null;
+
+    if (contentType.includes("application/json")) {
+      const { image } = await req.json();
+      if (typeof image === "string") {
+        imageData = image;
+      }
+    } else if (contentType.includes("multipart/form-data")) {
+      const form = await req.formData();
+      const file = form.get("file") as Blob | null;
+      if (file) {
+        const buffer = Buffer.from(await file.arrayBuffer());
+        imageData = `data:${file.type};base64,${buffer.toString("base64")}`;
+      }
+    }
+
+    if (!imageData) {
+      return NextResponse.json({ error: "No image provided" }, { status: 400 });
+    }
+
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text:
+              "Compare esta imagem com a foto do documento em nosso cadastro e responda apenas 'SIM' ou 'NAO'.",
+          },
+          { type: "image_url", image_url: { url: imageData } },
+        ],
+      },
+    ];
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages,
+    });
+
+    const text = completion.choices?.[0]?.message?.content?.trim() || "";
+    const verified = /^sim$/i.test(text);
+
+    return NextResponse.json({ verified, text });
+  } catch (error: any) {
+    console.error("Error in /verification:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/verification` endpoint using OpenAI to check a face frame
- capture an image when a face is centered and send it to this endpoint
- interpret verification response and broadcast confirmation or failure events
- update agent logic to react to verification result
- close camera automatically and add cancel flow

## Testing
- `npm test`
- `npm run lint`
