### PR TITLE
Handle verification cancellation event

### DIFF
--- a/src/app/simple/hooks/useVerificationProcess.ts
+++ b/src/app/simple/hooks/useVerificationProcess.ts
@@ -138,7 +138,7 @@ export const useVerificationProcess = (): UseVerificationProcessResult => {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
-    
+
     closeCamera();
     setState({
       active: false,
@@ -147,6 +147,9 @@ export const useVerificationProcess = (): UseVerificationProcessResult => {
       completionTime: null,
       error: null
     });
+    document.dispatchEvent(
+      new CustomEvent('camera-event', { detail: { type: 'VERIFICATION_CANCELLED' } })
+    );
   }, [closeCamera]);
   
   return {


### PR DESCRIPTION
## Summary
- emit `camera-event` when cancelling verification in hook
- confirm verification context also dispatches `VERIFICATION_CANCELLED`
- ensure Marlene agent processes the new event

## Testing
- `npm test`
