### PR TITLE
Handle camera closing event

### DIFF
--- a/src/app/agentConfigs/marlene.ts
+++ b/src/app/agentConfigs/marlene.ts
@@ -426,6 +426,12 @@ IMPORTANTE: SEMPRE que o usuário mencionar um valor de empréstimo desejado, us
           nextStep: "early_exit"
         };
       }
+      if (args.eventType === "CAMERA_CLOSING") {
+        return {
+          success: true,
+          message: "Fechando câmera",
+        };
+      }
       return {
         success: true,
         message: `Evento de câmera ${args.eventType} processado`

--- a/src/app/simple/contexts/VerificationContext.tsx
+++ b/src/app/simple/contexts/VerificationContext.tsx
@@ -269,6 +269,9 @@ export const VerificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
       cameraEventListenerRef.current = null;
     }
     verificationCompleteRef.current = false;
+    document.dispatchEvent(
+      new CustomEvent('camera-event', { detail: { type: 'CAMERA_CLOSING' } })
+    );
     closeCamera();
     dispatch({ type: 'CANCEL_VERIFICATION' });
 


### PR DESCRIPTION
## Summary
- emit CAMERA_CLOSING event when cancelling verification
- support CAMERA_CLOSING in Marlene agent logic

## Testing
- `npm test`
