### PR TITLE
Reset conversation context on each connect

### DIFF
--- a/src/app/simple/hooks/useWebRTCConnection.ts
+++ b/src/app/simple/hooks/useWebRTCConnection.ts
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { createRealtimeConnection } from '@/app/lib/realtimeConnection';
 import marleneConfig from '@/app/agentConfigs/marlene';
+import { resetConversationContext } from '@/app/agentConfigs/utils';
 
 interface ConnectionState {
   status: 'disconnected' | 'connecting' | 'connected';
@@ -38,6 +39,7 @@ export const useWebRTCConnection = (): UseWebRTCConnectionResult => {
   // Função para conectar
   const connect = useCallback(async () => {
     console.log('[useWebRTCConnection] connect called');
+    resetConversationContext();
     if (statusRef.current !== 'disconnected') {
       console.log('[useWebRTCConnection] connect aborted - already connecting');
       return;
@@ -186,6 +188,7 @@ export const useWebRTCConnection = (): UseWebRTCConnectionResult => {
   // Função para desconectar
   const disconnect = useCallback(() => {
     console.log('[useWebRTCConnection] disconnect called');
+    resetConversationContext();
     const dc = dcRef.current, pc = pcRef.current;
     
     // Tentar enviar mensagem de parada

--- a/src/app/simple/services/AgentService.ts
+++ b/src/app/simple/services/AgentService.ts
@@ -1,5 +1,6 @@
 // src/app/simple/services/AgentService.ts
 import marleneConfig from '@/app/agentConfigs/marlene';
+import { resetConversationContext } from '@/app/agentConfigs/utils';
 
 /**
  * Classe para gerenciar a comunicação com o agente Marlene
@@ -18,6 +19,7 @@ export class AgentService {
    */
   async connect(apiKey: string, audioElement: HTMLAudioElement | null): Promise<boolean> {
     try {
+      resetConversationContext();
       const { createRealtimeConnection } = await import('@/app/lib/realtimeConnection');
       
       // Garantir que temos um elemento de áudio
@@ -182,6 +184,7 @@ export class AgentService {
    * Desconecta do agente
    */
   disconnect(): void {
+    resetConversationContext();
     const dc = this.dataChannel, pc = this.connection;
     
     // Tentar enviar mensagem de parada


### PR DESCRIPTION
## Summary
- clear conversation context when starting or ending a WebRTC connection
- do the same in `AgentService`

## Testing
- `npm run lint`
- `npm test`
