### PR TITLE
Add offline playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You should be able to use this repo to prototype your own multi-agent realtime v
 
 ### Servidor de desenvolvimento
 - Inicie com `npm run dev` e acesse [http://localhost:3000](http://localhost:3000). O app conecta automaticamente ao Agent Set `simpleExample`.
+- Para testar somente a interface, sem precisar de conexão com a API, use [http://localhost:3000/playground](http://localhost:3000/playground). Esse modo roda offline e serve para experimentos de UI.
 
 ### Loan simulator backend
 Marlene consome o backend falso em `src/app/loanSimulator`. Rodar `npm run dev` com o Agent Set padrão (`marlene`) utiliza essas funções para simulações de empréstimo e ofertas Itaú.

--- a/src/app/playground/contexts/MockConnectionContext.tsx
+++ b/src/app/playground/contexts/MockConnectionContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { createContext, useContext } from "react";
+import { ConnectionState } from "../../simple/types";
+
+interface ConnectionContextType {
+  state: ConnectionState;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  sendMessage: (message: any) => boolean;
+  onAgentMessage: (listener: (message: any) => void) => () => void;
+}
+
+const MockConnectionContext = createContext<ConnectionContextType | undefined>(undefined);
+
+const fixedState: ConnectionState = {
+  status: "disconnected",
+  sessionId: null,
+  error: null,
+};
+
+export const MockConnectionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const connect = async () => {};
+  const disconnect = () => {};
+  const sendMessage = (_msg: any) => false;
+  const onAgentMessage = (_listener: (message: any) => void) => {
+    return () => {};
+  };
+
+  return (
+    <MockConnectionContext.Provider
+      value={{ state: fixedState, connect, disconnect, sendMessage, onAgentMessage }}
+    >
+      {children}
+    </MockConnectionContext.Provider>
+  );
+};
+
+export const useConnection = () => {
+  const context = useContext(MockConnectionContext);
+  if (!context) {
+    throw new Error("useConnection must be used within a MockConnectionProvider");
+  }
+  return context;
+};

--- a/src/app/playground/contexts/MockVerificationContext.tsx
+++ b/src/app/playground/contexts/MockVerificationContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+import { VerificationState } from "../../simple/types";
+
+const initialState: VerificationState = {
+  active: false,
+  step: 0,
+  startTime: null,
+  completionTime: null,
+  error: null,
+  faceDetectionStatus: {
+    detected: false,
+    centered: false,
+    verified: false,
+  },
+  pendingMessages: [],
+};
+
+interface VerificationContextType {
+  state: VerificationState;
+  startVerification: () => void;
+  cancelVerification: () => void;
+  processPendingMessages: () => void;
+}
+
+const MockVerificationContext = createContext<VerificationContextType | undefined>(undefined);
+
+export const MockVerificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<VerificationState>(initialState);
+
+  const startVerification = () => {
+    setState(prev => ({
+      ...prev,
+      active: true,
+      step: 1,
+      startTime: Date.now(),
+    }));
+  };
+
+  const cancelVerification = () => {
+    setState(initialState);
+  };
+
+  const processPendingMessages = () => {
+    setState(prev => ({ ...prev, pendingMessages: [] }));
+  };
+
+  return (
+    <MockVerificationContext.Provider value={{ state, startVerification, cancelVerification, processPendingMessages }}>
+      {children}
+    </MockVerificationContext.Provider>
+  );
+};
+
+export const useVerification = () => {
+  const ctx = useContext(MockVerificationContext);
+  if (!ctx) {
+    throw new Error("useVerification must be used within a MockVerificationProvider");
+  }
+  return ctx;
+};

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+import "@/app/styles/simple-page-styles.css";
+import { UIProvider } from "../simple/contexts/UIContext";
+import { CameraProvider } from "../simple/contexts/CameraContext";
+import { SimulationProvider } from "../simple/contexts/SimulationContext";
+import { MockConnectionProvider } from "./contexts/MockConnectionContext";
+import { MockVerificationProvider } from "./contexts/MockVerificationContext";
+import PhoneMockup from "../simple/components/PhoneMockup";
+import SimulationToggle from "../simple/components/SimulationToggle";
+import SimulationPanel from "../simple/components/SimulationPanel";
+
+const PlaygroundPage: React.FC = () => {
+  return (
+    <SimulationProvider>
+      <MockConnectionProvider>
+        <CameraProvider>
+          <MockVerificationProvider>
+            <UIProvider>
+              <div className="stage">
+                <div className="blur-backdrop"></div>
+                <PhoneMockup />
+                <SimulationToggle position="bottom-right" />
+                <SimulationPanel />
+              </div>
+            </UIProvider>
+          </MockVerificationProvider>
+        </CameraProvider>
+      </MockConnectionProvider>
+    </SimulationProvider>
+  );
+};
+
+export default PlaygroundPage;


### PR DESCRIPTION
## Summary
- mock connection and verification providers
- compose a new offline playground route at `/playground`
- document the new page in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*