### PR TITLE
Fix context usage in playground

### DIFF
--- a/src/app/playground/contexts/MockConnectionContext.tsx
+++ b/src/app/playground/contexts/MockConnectionContext.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { createContext, useContext } from "react";
+import React from "react";
 import { ConnectionState } from "../../simple/types";
+import { ConnectionContext } from "../../simple/contexts/ConnectionContext";
 
 interface ConnectionContextType {
   state: ConnectionState;
@@ -10,8 +11,6 @@ interface ConnectionContextType {
   sendMessage: (message: any) => boolean;
   onAgentMessage: (listener: (message: any) => void) => () => void;
 }
-
-const MockConnectionContext = createContext<ConnectionContextType | undefined>(undefined);
 
 const fixedState: ConnectionState = {
   status: "disconnected",
@@ -28,18 +27,10 @@ export const MockConnectionProvider: React.FC<{ children: React.ReactNode }> = (
   };
 
   return (
-    <MockConnectionContext.Provider
+    <ConnectionContext.Provider
       value={{ state: fixedState, connect, disconnect, sendMessage, onAgentMessage }}
     >
       {children}
-    </MockConnectionContext.Provider>
+    </ConnectionContext.Provider>
   );
-};
-
-export const useConnection = () => {
-  const context = useContext(MockConnectionContext);
-  if (!context) {
-    throw new Error("useConnection must be used within a MockConnectionProvider");
-  }
-  return context;
 };

--- a/src/app/playground/contexts/MockVerificationContext.tsx
+++ b/src/app/playground/contexts/MockVerificationContext.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { createContext, useContext, useState } from "react";
+import React, { useState } from "react";
 import { VerificationState } from "../../simple/types";
+import { VerificationContext } from "../../simple/contexts/VerificationContext";
 
 const initialState: VerificationState = {
   active: false,
@@ -24,8 +25,6 @@ interface VerificationContextType {
   processPendingMessages: () => void;
 }
 
-const MockVerificationContext = createContext<VerificationContextType | undefined>(undefined);
-
 export const MockVerificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, setState] = useState<VerificationState>(initialState);
 
@@ -47,16 +46,10 @@ export const MockVerificationProvider: React.FC<{ children: React.ReactNode }> =
   };
 
   return (
-    <MockVerificationContext.Provider value={{ state, startVerification, cancelVerification, processPendingMessages }}>
+    <VerificationContext.Provider
+      value={{ state, startVerification, cancelVerification, processPendingMessages }}
+    >
       {children}
-    </MockVerificationContext.Provider>
+    </VerificationContext.Provider>
   );
-};
-
-export const useVerification = () => {
-  const ctx = useContext(MockVerificationContext);
-  if (!ctx) {
-    throw new Error("useVerification must be used within a MockVerificationProvider");
-  }
-  return ctx;
 };

--- a/src/app/simple/contexts/ConnectionContext.tsx
+++ b/src/app/simple/contexts/ConnectionContext.tsx
@@ -12,7 +12,7 @@ interface ConnectionContextType {
   onAgentMessage: (listener: (message: any) => void) => () => void;
 }
 
-const ConnectionContext = createContext<ConnectionContextType | undefined>(undefined);
+export const ConnectionContext = createContext<ConnectionContextType | undefined>(undefined);
 
 export const ConnectionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { state, connect, disconnect, sendMessage, addMessageListener } = useWebRTCConnection();

--- a/src/app/simple/contexts/VerificationContext.tsx
+++ b/src/app/simple/contexts/VerificationContext.tsx
@@ -82,7 +82,7 @@ interface VerificationContextType {
   cancelVerification: () => void;
   processPendingMessages: () => void;
 }
-const VerificationContext = createContext<VerificationContextType | undefined>(undefined);
+export const VerificationContext = createContext<VerificationContextType | undefined>(undefined);
 
 export const VerificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, dispatch] = useReducer(verificationReducer, initialState);


### PR DESCRIPTION
## Summary
- export ConnectionContext and VerificationContext
- use those contexts in mock providers so hooks resolve correctly

## Testing
- `npm test`
