### PR TITLE
Fix open_camera tools and remove playground test buttons

### DIFF
--- a/src/app/playground/contexts/MockConnectionContext.tsx
+++ b/src/app/playground/contexts/MockConnectionContext.tsx
@@ -4,13 +4,6 @@ import React from "react";
 import { ConnectionState } from "../../simple/types";
 import { ConnectionContext } from "../../simple/contexts/ConnectionContext";
 
-interface ConnectionContextType {
-  state: ConnectionState;
-  connect: () => Promise<void>;
-  disconnect: () => void;
-  sendMessage: (message: any) => boolean;
-  onAgentMessage: (listener: (message: any) => void) => () => void;
-}
 
 const fixedState: ConnectionState = {
   status: "disconnected",
@@ -21,8 +14,8 @@ const fixedState: ConnectionState = {
 export const MockConnectionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const connect = async () => {};
   const disconnect = () => {};
-  const sendMessage = (_msg: any) => false;
-  const onAgentMessage = (_listener: (message: any) => void) => {
+  const sendMessage = () => false;
+  const onAgentMessage = () => {
     return () => {};
   };
 

--- a/src/app/playground/contexts/MockVerificationContext.tsx
+++ b/src/app/playground/contexts/MockVerificationContext.tsx
@@ -18,12 +18,6 @@ const initialState: VerificationState = {
   pendingMessages: [],
 };
 
-interface VerificationContextType {
-  state: VerificationState;
-  startVerification: () => void;
-  cancelVerification: () => void;
-  processPendingMessages: () => void;
-}
 
 export const MockVerificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, setState] = useState<VerificationState>(initialState);

--- a/src/app/simple/components/LoanValueAnimation.tsx
+++ b/src/app/simple/components/LoanValueAnimation.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useUI } from '../contexts/UIContext';
 
 const LoanValueAnimation: React.FC = () => {
-  const { loanState, showLoanAnimation, setRequestedLoanAmount } = useUI();
+  const { loanState } = useUI();
   const [moneyEmojis, setMoneyEmojis] = useState<Array<{
     id: number, 
     left: number, 
@@ -17,16 +17,6 @@ const LoanValueAnimation: React.FC = () => {
   // Ref para armazenar o timer da animação
   const animationTimerRef = useRef<NodeJS.Timeout | null>(null);
   const animationCountRef = useRef<number>(0);
-  
-  // Função de teste interna
-  const testSelf = () => {
-    console.log("🎬 Teste interno iniciado");
-    setRequestedLoanAmount('R$ 20.000,00');
-    
-    setTimeout(() => {
-      showLoanAnimation();
-    }, 500);
-  };
   
   // Gerar emojis quando a animação começa
   useEffect(() => {
@@ -126,47 +116,13 @@ const LoanValueAnimation: React.FC = () => {
     };
   }, []);
   
-  if (!loanState.showAnimation && !overlayVisible && moneyEmojis.length === 0) {
-    return (
-      <button
-        onClick={testSelf}
-        style={{
-          position: 'absolute',
-          top: '200px',
-          right: '10px',
-          zIndex: 1000,
-          padding: '5px',
-          background: '#ff0000',
-          color: 'white',
-          border: 'none',
-          borderRadius: '5px'
-        }}
-      >
-        Testar Direto
-      </button>
-    );
-  }
+if (!loanState.showAnimation && !overlayVisible && moneyEmojis.length === 0) {
+  return null;
+}
   
   return (
     <>
       {/* Botão de teste interno */}
-      <button
-        onClick={testSelf}
-        style={{
-          position: 'absolute',
-          top: '200px',
-          right: '10px',
-          zIndex: 1000,
-          padding: '5px',
-          background: '#ff0000',
-          color: 'white',
-          border: 'none',
-          borderRadius: '5px'
-        }}
-      >
-        Testar Direto
-      </button>
-      
       {/* Overlay de fundo */}
       <div 
         className={`loan-value-overlay ${overlayVisible ? 'visible' : ''}`} 

--- a/src/app/simple/components/PhoneMockup.tsx
+++ b/src/app/simple/components/PhoneMockup.tsx
@@ -12,25 +12,11 @@ import { useVerification } from '../contexts/VerificationContext';
 import Image from 'next/image';
 
 const PhoneMockup: React.FC = () => {
-  const { uiEvents, cameraRequests, removeCameraRequest, setRequestedLoanAmount, showLoanAnimation } = useUI();
+  const { uiEvents, cameraRequests, removeCameraRequest } = useUI();
   const { state: cameraState, openCamera } = useCamera();
   const { state: verificationState, startVerification } = useVerification();
   const videoRef = useRef<HTMLVideoElement | null>(null);
   
-  // Função de teste para a animação de valor
-  const testAnimation = () => {
-    console.log("⭐ Teste de animação iniciado");
-    
-    // Definir valor
-    setRequestedLoanAmount('R$ 10.000,00');
-    console.log("⭐ Valor definido: R$ 10.000,00");
-    
-    // Mostrar a animação com um breve atraso
-    setTimeout(() => {
-      console.log("⭐ Acionando animação");
-      showLoanAnimation();
-    }, 500);
-  };
   
   // Quando receber o stream, anexar ao <video>
   useEffect(() => {
@@ -115,23 +101,6 @@ const PhoneMockup: React.FC = () => {
           </div>
         ))}
         
-        {/* Botão de teste da animação */}
-        <button 
-          onClick={testAnimation}
-          style={{
-            position: 'absolute',
-            top: '150px',
-            left: '10px',
-            zIndex: 100,
-            padding: '5px',
-            background: '#ff8548',
-            color: 'white',
-            border: 'none',
-            borderRadius: '5px'
-          }}
-        >
-          Testar animação
-        </button>
         
         {/* Preview da câmera */}
         {cameraState.active && (

--- a/src/app/simple/contexts/CameraContext.tsx
+++ b/src/app/simple/contexts/CameraContext.tsx
@@ -89,7 +89,6 @@ export const CameraProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       }
       closeCamera();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Abre a câmera e inicia detecção
@@ -280,6 +279,16 @@ export const CameraProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       catch (e) { console.warn("Error clearing video source:", e); }
     }
   }
+
+  useEffect(() => {
+    const handleSimClose = () => {
+      closeCamera();
+    };
+    document.addEventListener('simulated-camera-close', handleSimClose as EventListener);
+    return () => {
+      document.removeEventListener('simulated-camera-close', handleSimClose as EventListener);
+    };
+  }, []);
 
   const contextValue: CameraContextType = {
     state,

--- a/src/app/simple/contexts/UIContext.tsx
+++ b/src/app/simple/contexts/UIContext.tsx
@@ -274,6 +274,32 @@ export const UIProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       document.removeEventListener('loan-animation-trigger', handleAnimationTrigger);
     };
   }, [loanState.requestedAmount]);
+
+  // Eventos simulados para câmera e UI
+  useEffect(() => {
+    const handleAddCamera = (e: CustomEvent) => {
+      const left = e.detail?.left ?? 50;
+      addCameraRequest(left);
+    };
+    const handleCameraClose = () => {
+      setCameraRequests([]);
+    };
+    const handleUIEventSim = (e: CustomEvent) => {
+      if (e.detail) addUIEvent(e.detail);
+    };
+
+    document.addEventListener('add-camera-request', handleAddCamera as EventListener);
+    document.addEventListener('simulated-camera-request', handleAddCamera as EventListener);
+    document.addEventListener('simulated-camera-close', handleCameraClose as EventListener);
+    document.addEventListener('simulated-ui-event', handleUIEventSim as EventListener);
+
+    return () => {
+      document.removeEventListener('add-camera-request', handleAddCamera as EventListener);
+      document.removeEventListener('simulated-camera-request', handleAddCamera as EventListener);
+      document.removeEventListener('simulated-camera-close', handleCameraClose as EventListener);
+      document.removeEventListener('simulated-ui-event', handleUIEventSim as EventListener);
+    };
+  }, []);
   
   
   // Função para extrair e normalizar valor monetário de um texto


### PR DESCRIPTION
## Summary
- remove playground test buttons
- handle camera and ui events for playground simulation
- close camera when simulation sends closing event
- clean up unused code and lint errors

## Testing
- `npm run lint`
- `npm test`
