### PR TITLE
Implement run-id persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Marlene é um agente de voz configurado em `src/app/agentConfigs/marlene.ts`. El
 ## O que mudou recentemente
 - Julho/2024: adicionada opcao de pre-commit hook com testes e lint.
 - Agosto/2024: gerenciamento da conversa movido para uma XState machine dedicada.
+- Setembro/2024: adicionada persistência de contexto via run-id e localStorage.
 - Junho/2024: adicionadas orientacoes de contribuicao em CONTRIBUTING.md.
 - Maio/2024: projeto iniciado como demonstração do agente Marlene e fluxo de concessão de crédito consignado.
 
@@ -21,6 +22,7 @@ Marlene é um agente de voz configurado em `src/app/agentConfigs/marlene.ts`. El
 - `src/app/loanSimulator/index.ts` – backend falso que gera dados de benefício e simulações de empréstimo.
 - `src/app/simple/machines/verificationMachine.ts` – máquina de estados para a verificação facial via câmera.
 - `src/app/simple/machines/conversationMachine.ts` – controla o fluxo principal da conversa.
+- `src/app/simple/services/ConversationStateService.ts` – salva e carrega o contexto da conversa no `localStorage` com base no run-id.
 
 ## Máquina de Estados da Conversa
 O fluxo da conversa é guiado por nove estados principais. A cada mensagem do usuário, `processUserInputAsync` extrai entidades (nome, número de benefício, valor desejado etc.) e `conversationMachine` decide para qual estado seguir.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ You should be able to use this repo to prototype your own multi-agent realtime v
 Marlene consome o backend falso em `src/app/loanSimulator`. Rodar `npm run dev` com o Agent Set padrão (`marlene`) utiliza essas funções para simulações de empréstimo e ofertas Itaú.
 Com `NEXT_PUBLIC_USE_LLM_BACKEND=true`, o simulador passa a chamar `/api/loan/consult`, gerando dados consistentes via modelo OpenAI. O resultado fica em `data/llm-benefit-cache.json` e o diretório `data/` é criado automaticamente se ainda não existir.
 
+### Persistência de conversa
+O endpoint `/api/run-id` retorna um identificador único para cada execução do backend. O frontend salva esse valor junto com o contexto da conversa no `localStorage`. Ao recarregar a página, `rehydrateContext` verifica o run-id atual; se for igual ao salvo, a conversa é retomada de onde parou. Se o backend tiver reiniciado e o run-id mudar, o histórico é apagado automaticamente. Para começar do zero manualmente, utilize `restartConversation()`.
+
 ## Testes e lint
 - `npm test` executa a suíte Jest.
 - `npm run lint` roda o linter do projeto.

--- a/__tests__/conversationPersistence.test.ts
+++ b/__tests__/conversationPersistence.test.ts
@@ -1,0 +1,55 @@
+import { jest } from '@jest/globals';
+
+function mockLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+  } as Storage;
+}
+
+describe('conversation persistence', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    (global as any).localStorage = mockLocalStorage();
+  });
+
+  test('rehydrates context when run-id matches', async () => {
+    const utils = await import('@/app/agentConfigs/utils');
+    const service = await import('@/app/simple/services/ConversationStateService');
+
+    utils.resetConversationContext();
+    utils.updateContext({ name: 'Ana' });
+    service.saveContext(utils.exportContext(), 'run1');
+    utils.resetConversationContext();
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ runId: 'run1' }),
+    });
+
+    const restored = await utils.rehydrateContext();
+    expect(restored).toBe(true);
+    expect(utils.exportContext().name).toBe('Ana');
+  });
+
+  test('clears context when run-id changes', async () => {
+    const utils = await import('@/app/agentConfigs/utils');
+    const service = await import('@/app/simple/services/ConversationStateService');
+
+    utils.resetConversationContext();
+    utils.updateContext({ name: 'Ana' });
+    service.saveContext(utils.exportContext(), 'run1');
+    utils.resetConversationContext();
+
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ runId: 'run2' }),
+    });
+
+    const restored = await utils.rehydrateContext();
+    expect(restored).toBe(false);
+    expect(utils.exportContext().name).toBeUndefined();
+    expect(service.getStoredRunId()).toBe('run2');
+  });
+});

--- a/src/app/api/run-id/route.ts
+++ b/src/app/api/run-id/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const RUN_ID = Date.now().toString();
+
+export async function GET() {
+  return NextResponse.json({ runId: RUN_ID });
+}

--- a/src/app/simple/hooks/useWebRTCConnection.ts
+++ b/src/app/simple/hooks/useWebRTCConnection.ts
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { createRealtimeConnection } from '@/app/lib/realtimeConnection';
 import marleneConfig from '@/app/agentConfigs/marlene';
-import { resetConversationContext } from '@/app/agentConfigs/utils';
+import { resetConversationContext, rehydrateContext } from '@/app/agentConfigs/utils';
 
 interface ConnectionState {
   status: 'disconnected' | 'connecting' | 'connected';
@@ -39,7 +39,10 @@ export const useWebRTCConnection = (): UseWebRTCConnectionResult => {
   // Função para conectar
   const connect = useCallback(async () => {
     console.log('[useWebRTCConnection] connect called');
-    resetConversationContext();
+    const restored = await rehydrateContext();
+    if (!restored) {
+      resetConversationContext();
+    }
     if (statusRef.current !== 'disconnected') {
       console.log('[useWebRTCConnection] connect aborted - already connecting');
       return;

--- a/src/app/simple/services/AgentService.ts
+++ b/src/app/simple/services/AgentService.ts
@@ -1,6 +1,6 @@
 // src/app/simple/services/AgentService.ts
 import marleneConfig from '@/app/agentConfigs/marlene';
-import { resetConversationContext } from '@/app/agentConfigs/utils';
+import { resetConversationContext, rehydrateContext } from '@/app/agentConfigs/utils';
 
 /**
  * Classe para gerenciar a comunicação com o agente Marlene
@@ -19,7 +19,10 @@ export class AgentService {
    */
   async connect(apiKey: string, audioElement: HTMLAudioElement | null): Promise<boolean> {
     try {
-      resetConversationContext();
+      const restored = await rehydrateContext();
+      if (!restored) {
+        resetConversationContext();
+      }
       const { createRealtimeConnection } = await import('@/app/lib/realtimeConnection');
       
       // Garantir que temos um elemento de áudio

--- a/src/app/simple/services/ConversationStateService.ts
+++ b/src/app/simple/services/ConversationStateService.ts
@@ -1,0 +1,27 @@
+import { localStorageService } from './LocalStorageService';
+
+const CONTEXT_KEY = 'conversation_context';
+const RUN_ID_KEY = 'run_id';
+
+export interface StoredConversation {
+  context: any;
+  runId: string | null;
+}
+
+export function saveContext(context: any, runId?: string): void {
+  if (runId) localStorageService.setItem(RUN_ID_KEY, runId);
+  localStorageService.setItem(CONTEXT_KEY, context);
+}
+
+export function loadContext(): any | null {
+  return localStorageService.getItem<any | null>(CONTEXT_KEY, null);
+}
+
+export function clearContext(): void {
+  localStorageService.removeItem(CONTEXT_KEY);
+  localStorageService.removeItem(RUN_ID_KEY);
+}
+
+export function getStoredRunId(): string | null {
+  return localStorageService.getItem<string | null>(RUN_ID_KEY, null);
+}


### PR DESCRIPTION
## Summary
- add `/api/run-id` endpoint to expose a backend run identifier
- store conversation context in `ConversationStateService`
- rehydrate context on connect and restart if run-id changed
- provide manual `restartConversation` helper
- test conversation persistence
- document run-id behaviour

## Testing
- `npm run lint`
- `npm test`
